### PR TITLE
Add EncodeWithRand

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -176,7 +176,7 @@ func (kse *keyStoreEncoder) writePrivateKeyEntry(alias string, pke *PrivateKeyEn
 	return nil
 }
 
-// Encode encrypts and sign keystore using password and write its representation into w
+// Encode encrypts and signs keystore using password and writes its representation into w
 // It is strongly recommended to fill password slice with zero after usage
 func Encode(w io.Writer, ks KeyStore, password []byte) error {
 	kse := keyStoreEncoder{

--- a/keyprotector.go
+++ b/keyprotector.go
@@ -1,11 +1,11 @@
 package keystore
 
 import (
-	"crypto/rand"
 	"crypto/sha1"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"errors"
+	"io"
 )
 
 const saltLen = 20
@@ -92,7 +92,7 @@ func recoverKey(encodedKey []byte, password []byte) ([]byte, error) {
 	return plainKey, nil
 }
 
-func protectKey(plainKey []byte, password []byte) ([]byte, error) {
+func protectKey(rand io.Reader, plainKey []byte, password []byte) ([]byte, error) {
 	md := sha1.New()
 	passwdBytes := passwordBytes(password)
 	defer zeroing(passwdBytes)


### PR DESCRIPTION
Thanks for writing this great library!

This pull request adds `EncodeWithRand`, which is like `Encode` but allows you to specify the CSPRNG.  This is useful for testing (since you can use a deterministic RNG) and for special cases where you need to use the non-default CSPRNG.