### PR TITLE
Include explicit NULL parameters value when encoding private key

### DIFF
--- a/keyprotector.go
+++ b/keyprotector.go
@@ -153,6 +153,7 @@ func protectKey(plainKey []byte, password []byte) ([]byte, error) {
 	keyInfo := keyInfo{
 		Algo: pkix.AlgorithmIdentifier{
 			Algorithm: supportedPrivateKeyAlgorithmOid,
+			Parameters: asn1.RawValue{Tag: 5},
 		},
 		PrivateKey: encrKey,
 	}


### PR DESCRIPTION
The Java keystore tool includes an explicit NULL value for `Parameters`, and the poster at https://www.cem.me/20150315-cert-binaries-6.html shows it, so it seems like a good idea to include it for compatibility.