### PR TITLE
Reproducible KeyStore

### DIFF
--- a/keystore.go
+++ b/keystore.go
@@ -88,8 +88,8 @@ func (ks KeyStore) Store(w io.Writer, password []byte) error {
 		return fmt.Errorf("write number of entries: %w", err)
 	}
 
-	for alias, entry := range ks.m {
-		switch typedEntry := entry.(type) {
+	for _, alias := range ks.Aliases() {
+		switch typedEntry := ks.m[alias].(type) {
 		case PrivateKeyEntry:
 			if err := kse.writePrivateKeyEntry(alias, typedEntry); err != nil {
 				return fmt.Errorf("write private key entry: %w", err)


### PR DESCRIPTION
Previously, when a KeyStore was stored (written out) the order that the entries were written was non-deterministic, depending on the iteration order of map, which in Go is both undefined and in practice, variable.  The result of the non-deterministic ordering was that while multiple writes of the same set of entries into a KeyStore would result in functionally equivalent files on the file system, they actual bytes would not be identical.  For most scenarios this doesn't matter, but for Docker image layers, it absolutely does.  Without identical bytes, layer de-duplication and transfer avoidance cannot be performed.

This change ensures that entries are always written into the KeyStore in a deterministic order (lexically sorted by alias), and the result is byte-identical to all other writes with the same entries.
