### PR TITLE
keystore-go-32 Update golangci-lint version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2.5.2
         with:
           args: --timeout=5m0s -c .golangci.yaml
-          version: v1.41
+          version: v1.43
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - golint
     - interfacer
     - maligned
+    - varnamelen
 
 linters-settings:
   gomnd:


### PR DESCRIPTION
#32 