### PR TITLE
Refactor using testify and upgrade go v1.22.7

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
       - name: Lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout=5m0s -c .golangci.yaml
-          version: v1.54.2
+          version: v1.61.0
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.22.7'
       - name: Fmt
         run: go fmt github.com/pavlo-v-chernykh/keystore-go/v4/...
   lint:
@@ -33,6 +33,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.22.7'
       - name: Test
         run: go test -cover -count=1 -v github.com/pavlo-v-chernykh/keystore-go/v4/...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,9 @@ linters:
     - makezero
     - varnamelen
     - exhaustruct
+    - gomnd  # because WARN The linter 'gomnd' is deprecated (since v1.58.0) due to: The linter has been renamed. Replaced by mnd.
+    - exportloopref  # because WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
+    - execinquery  # because WARN The linter 'execinquery' is deprecated (since v1.58.0) due to: The repository of the linter has been archived by the owner.
 
 linters-settings:
   cyclop:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,10 +18,6 @@ linters:
     - exhaustruct
 
 linters-settings:
-  gomnd:
-    settings:
-      mnd:
-        checks: [case, condition, return]
   cyclop:
     max-complexity: 15
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,6 +27,8 @@ linters-settings:
 
 
 issues:
+  exclude:
+    - import '.*' is not allowed from list 'Main'
   exclude-rules:
     - path: _test\.go
       linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,7 @@ linters:
   disable:
     - gochecknoglobals
     - funlen
-    - goerr113
+    - err113
     - gofumpt
     - gomoddirectives
     - makezero

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,13 +7,8 @@ linters:
     - funlen
     - goerr113
     - gofumpt
-    - exhaustivestruct
     - gomoddirectives
-    - scopelint
     - makezero
-    - golint
-    - interfacer
-    - maligned
     - varnamelen
     - exhaustruct
 

--- a/common.go
+++ b/common.go
@@ -19,7 +19,7 @@ var byteOrder = binary.BigEndian
 var whitenerMessage = []byte("Mighty Aphrodite")
 
 func passwordBytes(password []byte) []byte {
-	result := make([]byte, 0, len(password)*2)
+	result := make([]byte, 0, len(password)*2) //nolint:gomnd,mnd
 	for _, b := range password {
 		result = append(result, 0, b)
 	}

--- a/common_test.go
+++ b/common_test.go
@@ -2,7 +2,6 @@ package keystore
 
 import (
 	"crypto/rand"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,6 +57,6 @@ func TestPasswordBytes(t *testing.T) {
 
 	for _, tt := range table {
 		output := passwordBytes(tt.input)
-		assert.Truef(t, reflect.DeepEqual(output, tt.output), "convert password bytes '%v', '%v'", output, tt.output)
+		assert.Equal(t, tt.output, output, "convert password bytes")
 	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -3,6 +3,7 @@ package keystore
 import (
 	"crypto/rand"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 )
@@ -13,7 +14,7 @@ func TestZeroing(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		buf := make([]byte, 4096)
 		_, err := rand.Read(buf)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		table = append(table, buf)
 	}
@@ -38,7 +39,7 @@ func TestPasswordBytes(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		input := make([]byte, 1024)
 		_, err := rand.Read(input)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		output := make([]byte, len(input)*2)
 

--- a/common_test.go
+++ b/common_test.go
@@ -2,21 +2,24 @@ package keystore
 
 import (
 	"crypto/rand"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestZeroing(t *testing.T) {
-	var table [][]byte
+	const tableLength = 20
 
-	for i := 0; i < 20; i++ {
+	var table = make([][]byte, tableLength)
+
+	for i := range tableLength {
 		buf := make([]byte, 4096)
 		_, err := rand.Read(buf)
 		require.NoError(t, err)
 
-		table = append(table, buf)
+		table[i] = buf
 	}
 
 	for _, tt := range table {
@@ -34,9 +37,11 @@ func TestPasswordBytes(t *testing.T) {
 		output []byte
 	}
 
-	var table []item
+	const tableLength = 20
 
-	for i := 0; i < 20; i++ {
+	var table = make([]item, tableLength)
+
+	for i := range tableLength {
 		input := make([]byte, 1024)
 		_, err := rand.Read(input)
 		require.NoError(t, err)
@@ -48,7 +53,7 @@ func TestPasswordBytes(t *testing.T) {
 			output[j+1] = input[k]
 		}
 
-		table = append(table, item{input: input, output: output})
+		table[i] = item{input: input, output: output}
 	}
 
 	for _, tt := range table {

--- a/common_test.go
+++ b/common_test.go
@@ -2,6 +2,7 @@ package keystore
 
 import (
 	"crypto/rand"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
@@ -11,9 +12,8 @@ func TestZeroing(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		buf := make([]byte, 4096)
-		if _, err := rand.Read(buf); err != nil {
-			t.Errorf("read random bytes: %v", err)
-		}
+		_, err := rand.Read(buf)
+		assert.Nil(t, err)
 
 		table = append(table, buf)
 	}
@@ -22,9 +22,7 @@ func TestZeroing(t *testing.T) {
 		zeroing(tt)
 
 		for i := range tt {
-			if tt[i] != 0 {
-				t.Errorf("fill input with zeros '%v'", tt)
-			}
+			assert.Equalf(t, uint8(0), tt[i], "fill input with zeros '%v'", tt)
 		}
 	}
 }
@@ -39,9 +37,8 @@ func TestPasswordBytes(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		input := make([]byte, 1024)
-		if _, err := rand.Read(input); err != nil {
-			t.Errorf("read random bytes: %v", err)
-		}
+		_, err := rand.Read(input)
+		assert.Nil(t, err)
 
 		output := make([]byte, len(input)*2)
 
@@ -55,8 +52,6 @@ func TestPasswordBytes(t *testing.T) {
 
 	for _, tt := range table {
 		output := passwordBytes(tt.input)
-		if !reflect.DeepEqual(output, tt.output) {
-			t.Errorf("convert password bytes '%v', '%v'", output, tt.output)
-		}
+		assert.Truef(t, reflect.DeepEqual(output, tt.output), "convert password bytes '%v', '%v'", output, tt.output)
 	}
 }

--- a/decoder.go
+++ b/decoder.go
@@ -128,7 +128,7 @@ func (d decoder) readPrivateKeyEntry(version uint32) (PrivateKeyEntry, error) {
 		chain = append(chain, cert)
 	}
 
-	creationDateTime := time.UnixMilli(int64(creationTimeStamp)) //nolint:all
+	creationDateTime := time.UnixMilli(int64(creationTimeStamp)) //nolint:gosec
 	privateKeyEntry := PrivateKeyEntry{
 		PrivateKey:       encryptedPrivateKey,
 		CreationTime:     creationDateTime,
@@ -149,7 +149,7 @@ func (d decoder) readTrustedCertificateEntry(version uint32) (TrustedCertificate
 		return TrustedCertificateEntry{}, fmt.Errorf("read certificate: %w", err)
 	}
 
-	creationDateTime := time.UnixMilli(int64(creationTimeStamp)) //nolint:all
+	creationDateTime := time.UnixMilli(int64(creationTimeStamp)) //nolint:gosec
 	trustedCertificateEntry := TrustedCertificateEntry{
 		CreationTime: creationDateTime,
 		Certificate:  certificate,

--- a/decoder.go
+++ b/decoder.go
@@ -16,19 +16,19 @@ type decoder struct {
 }
 
 func (d decoder) readUint16() (uint16, error) {
-	b, err := d.readBytes(2)
+	b, err := d.readBytes(2) //nolint:gomnd,mnd
 
 	return byteOrder.Uint16(b), err
 }
 
 func (d decoder) readUint32() (uint32, error) {
-	b, err := d.readBytes(4)
+	b, err := d.readBytes(4) //nolint:gomnd,mnd
 
 	return byteOrder.Uint32(b), err
 }
 
 func (d decoder) readUint64() (uint64, error) {
-	b, err := d.readBytes(8)
+	b, err := d.readBytes(8) //nolint:gomnd,mnd
 
 	return byteOrder.Uint64(b), err
 }

--- a/decoder.go
+++ b/decoder.go
@@ -119,7 +119,7 @@ func (d decoder) readPrivateKeyEntry(version uint32) (PrivateKeyEntry, error) {
 
 	chain := make([]Certificate, 0, certNum)
 
-	for i := uint32(0); i < certNum; i++ {
+	for i := range certNum {
 		cert, err := d.readCertificate(version)
 		if err != nil {
 			return PrivateKeyEntry{}, fmt.Errorf("read %d certificate: %w", i, err)
@@ -128,7 +128,7 @@ func (d decoder) readPrivateKeyEntry(version uint32) (PrivateKeyEntry, error) {
 		chain = append(chain, cert)
 	}
 
-	creationDateTime := time.UnixMilli(int64(creationTimeStamp))
+	creationDateTime := time.UnixMilli(int64(creationTimeStamp)) //nolint:all
 	privateKeyEntry := PrivateKeyEntry{
 		PrivateKey:       encryptedPrivateKey,
 		CreationTime:     creationDateTime,
@@ -149,7 +149,7 @@ func (d decoder) readTrustedCertificateEntry(version uint32) (TrustedCertificate
 		return TrustedCertificateEntry{}, fmt.Errorf("read certificate: %w", err)
 	}
 
-	creationDateTime := time.UnixMilli(int64(creationTimeStamp))
+	creationDateTime := time.UnixMilli(int64(creationTimeStamp)) //nolint:all
 	trustedCertificateEntry := TrustedCertificateEntry{
 		CreationTime: creationDateTime,
 		Certificate:  certificate,

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"reflect"
 	"testing"
@@ -69,20 +70,14 @@ func TestReadUint16(t *testing.T) {
 		}
 
 		number, err := d.readUint16()
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("invalid error '%v' '%v'", err, tt.err)
-		}
+		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
 
 		if err == nil {
-			if number != tt.number {
-				t.Errorf("invalid number '%v' '%v'", number, tt.number)
-			}
+			assert.Equal(t, tt.number, number)
 		}
 
 		hash := d.h.Sum(nil)
-		if !reflect.DeepEqual(hash, tt.hash[:]) {
-			t.Errorf("invalid hash '%v' '%v'", hash, tt.hash)
-		}
+		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
 	}
 }
 
@@ -143,20 +138,14 @@ func TestReadUint32(t *testing.T) {
 		}
 
 		number, err := d.readUint32()
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("invalid error '%v' '%v'", err, tt.err)
-		}
+		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
 
 		if err == nil {
-			if number != tt.number {
-				t.Errorf("invalid uint32 '%v' '%v'", number, tt.number)
-			}
+			assert.Equal(t, tt.number, number)
 		}
 
 		hash := d.h.Sum(nil)
-		if !reflect.DeepEqual(hash, tt.hash[:]) {
-			t.Errorf("invalid hash '%v' '%v'", hash, tt.hash)
-		}
+		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
 	}
 }
 
@@ -221,20 +210,14 @@ func TestReadUint64(t *testing.T) {
 		}
 
 		number, err := d.readUint64()
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("invalid error '%v' '%v'", err, tt.err)
-		}
+		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
 
 		if err == nil {
-			if number != tt.number {
-				t.Errorf("invalid uint64 '%v' '%v'", number, tt.number)
-			}
+			assert.Equal(t, tt.number, number)
 		}
 
 		hash := d.h.Sum(nil)
-		if !reflect.DeepEqual(hash, tt.hash[:]) {
-			t.Errorf("invalid hash '%v' '%v'", hash, tt.hash)
-		}
+		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
 	}
 }
 
@@ -268,9 +251,8 @@ func TestReadBytes(t *testing.T) {
 		})
 		buf := func() []byte {
 			buf := make([]byte, 10*1024)
-			if _, err := rand.Read(buf); err != nil {
-				t.Errorf("read random bytes: %v", err)
-			}
+			_, err := rand.Read(buf)
+			assert.Nil(t, err)
 
 			return buf
 		}()
@@ -292,18 +274,12 @@ func TestReadBytes(t *testing.T) {
 		}
 
 		bts, err := d.readBytes(tt.readLen)
-		if err != nil {
-			t.Errorf("got error '%v'", err)
-		}
+		assert.Nil(t, err)
 
-		if !reflect.DeepEqual(bts, tt.bytes) {
-			t.Errorf("invalid bytes '%v' '%v'", bts, tt.bytes)
-		}
+		assert.Truef(t, reflect.DeepEqual(bts, tt.bytes), "invalid bytes '%v' '%v'", bts, tt.bytes)
 
 		hash := d.h.Sum(nil)
-		if !reflect.DeepEqual(hash, tt.hash[:]) {
-			t.Errorf("invalid hash '%v' '%v'", hash, tt.hash)
-		}
+		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
 	}
 }
 
@@ -362,18 +338,11 @@ func TestReadString(t *testing.T) {
 		}
 
 		str, err := d.readString()
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("invalid error '%v' '%v'", err, tt.err)
-		}
-
-		if str != tt.string {
-			t.Errorf("invalid string '%v' '%v'", str, tt.string)
-		}
+		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
+		assert.Equal(t, tt.string, str)
 
 		hash := d.h.Sum(nil)
-		if !reflect.DeepEqual(hash, tt.hash[:]) {
-			t.Errorf("invalid hash '%v' '%v'", hash, tt.hash)
-		}
+		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
 	}
 }
 
@@ -468,17 +437,10 @@ func TestReadCertificate(t *testing.T) {
 		}
 
 		cert, err := d.readCertificate(tt.version)
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("invalid error '%v' '%v'", err, tt.err)
-		}
-
-		if !reflect.DeepEqual(cert, tt.cert) {
-			t.Errorf("invalid certificate '%v' '%v'", cert, tt.cert)
-		}
+		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
+		assert.Truef(t, reflect.DeepEqual(cert, tt.cert), "invalid certificate '%v' '%v'", cert, tt.cert)
 
 		hash := d.h.Sum(nil)
-		if !reflect.DeepEqual(hash, tt.hash[:]) {
-			t.Errorf("invalid hash '%v' '%v'", hash, tt.hash)
-		}
+		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
 	}
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"io"
 	"reflect"
 	"testing"
@@ -252,7 +253,7 @@ func TestReadBytes(t *testing.T) {
 		buf := func() []byte {
 			buf := make([]byte, 10*1024)
 			_, err := rand.Read(buf)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			return buf
 		}()
@@ -274,7 +275,7 @@ func TestReadBytes(t *testing.T) {
 		}
 
 		bts, err := d.readBytes(tt.readLen)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		assert.Truef(t, reflect.DeepEqual(bts, tt.bytes), "invalid bytes '%v' '%v'", bts, tt.bytes)
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -7,11 +7,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadUint16(t *testing.T) {
@@ -320,7 +321,7 @@ func TestReadString(t *testing.T) {
 		})
 		str := "some string to read"
 		buf := make([]byte, 2)
-		binary.BigEndian.PutUint16(buf, uint16(len(str)))
+		binary.BigEndian.PutUint16(buf, uint16(len(str))) //nolint:all
 		buf = append(buf, []byte(str)...)
 		table = append(table, item{
 			input:  buf,

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,14 +71,14 @@ func TestReadUint16(t *testing.T) {
 		}
 
 		number, err := d.readUint16()
-		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
+		assert.Equal(t, tt.err, err)
 
 		if err == nil {
 			assert.Equal(t, tt.number, number)
 		}
 
 		hash := d.h.Sum(nil)
-		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
+		assert.Equal(t, tt.hash[:], hash)
 	}
 }
 
@@ -140,14 +139,14 @@ func TestReadUint32(t *testing.T) {
 		}
 
 		number, err := d.readUint32()
-		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
+		assert.Equal(t, tt.err, err)
 
 		if err == nil {
 			assert.Equal(t, tt.number, number)
 		}
 
 		hash := d.h.Sum(nil)
-		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
+		assert.Equal(t, tt.hash[:], hash)
 	}
 }
 
@@ -212,14 +211,14 @@ func TestReadUint64(t *testing.T) {
 		}
 
 		number, err := d.readUint64()
-		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
+		assert.Equal(t, tt.err, err)
 
 		if err == nil {
 			assert.Equal(t, tt.number, number)
 		}
 
 		hash := d.h.Sum(nil)
-		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
+		assert.Equal(t, tt.hash[:], hash)
 	}
 }
 
@@ -278,10 +277,10 @@ func TestReadBytes(t *testing.T) {
 		bts, err := d.readBytes(tt.readLen)
 		require.NoError(t, err)
 
-		assert.Truef(t, reflect.DeepEqual(bts, tt.bytes), "invalid bytes '%v' '%v'", bts, tt.bytes)
+		assert.Equal(t, tt.bytes, bts)
 
 		hash := d.h.Sum(nil)
-		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
+		assert.Equal(t, tt.hash[:], hash)
 	}
 }
 
@@ -321,7 +320,7 @@ func TestReadString(t *testing.T) {
 		})
 		str := "some string to read"
 		buf := make([]byte, 2)
-		binary.BigEndian.PutUint16(buf, uint16(len(str))) //nolint:all
+		binary.BigEndian.PutUint16(buf, uint16(len(str))) //nolint:gosec
 		buf = append(buf, []byte(str)...)
 		table = append(table, item{
 			input:  buf,
@@ -340,11 +339,11 @@ func TestReadString(t *testing.T) {
 		}
 
 		str, err := d.readString()
-		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
+		assert.Equal(t, tt.err, err)
 		assert.Equal(t, tt.string, str)
 
 		hash := d.h.Sum(nil)
-		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
+		assert.Equal(t, tt.hash[:], hash)
 	}
 }
 
@@ -439,10 +438,10 @@ func TestReadCertificate(t *testing.T) {
 		}
 
 		cert, err := d.readCertificate(tt.version)
-		assert.Truef(t, reflect.DeepEqual(err, tt.err), "invalid error '%v' '%v'", err, tt.err)
-		assert.Truef(t, reflect.DeepEqual(cert, tt.cert), "invalid certificate '%v' '%v'", cert, tt.cert)
+		assert.Equal(t, tt.err, err)
+		assert.Equal(t, tt.cert, cert)
 
 		hash := d.h.Sum(nil)
-		assert.Truef(t, reflect.DeepEqual(hash, tt.hash[:]), "invalid hash '%v' '%v'", hash, tt.hash)
+		assert.Equal(t, tt.hash[:], hash)
 	}
 }

--- a/encoder.go
+++ b/encoder.go
@@ -95,7 +95,7 @@ func (e encoder) writePrivateKeyEntry(alias string, pke PrivateKeyEntry) error {
 		return fmt.Errorf("write alias: %w", err)
 	}
 
-	if err := e.writeUint64(uint64(pke.CreationTime.UnixMilli())); err != nil { //nolint:all
+	if err := e.writeUint64(uint64(pke.CreationTime.UnixMilli())); err != nil { //nolint:gosec
 		return fmt.Errorf("write creation timestamp: %w", err)
 	}
 
@@ -140,7 +140,7 @@ func (e encoder) writeTrustedCertificateEntry(alias string, tce TrustedCertifica
 		return fmt.Errorf("write alias: %w", err)
 	}
 
-	if err := e.writeUint64(uint64(tce.CreationTime.UnixMilli())); err != nil { //nolint:all
+	if err := e.writeUint64(uint64(tce.CreationTime.UnixMilli())); err != nil { //nolint:gosec
 		return fmt.Errorf("write creation timestamp: %w", err)
 	}
 

--- a/encoder.go
+++ b/encoder.go
@@ -95,7 +95,7 @@ func (e encoder) writePrivateKeyEntry(alias string, pke PrivateKeyEntry) error {
 		return fmt.Errorf("write alias: %w", err)
 	}
 
-	if err := e.writeUint64(uint64(pke.CreationTime.UnixMilli())); err != nil {
+	if err := e.writeUint64(uint64(pke.CreationTime.UnixMilli())); err != nil { //nolint:all
 		return fmt.Errorf("write creation timestamp: %w", err)
 	}
 
@@ -140,7 +140,7 @@ func (e encoder) writeTrustedCertificateEntry(alias string, tce TrustedCertifica
 		return fmt.Errorf("write alias: %w", err)
 	}
 
-	if err := e.writeUint64(uint64(tce.CreationTime.UnixMilli())); err != nil {
+	if err := e.writeUint64(uint64(tce.CreationTime.UnixMilli())); err != nil { //nolint:all
 		return fmt.Errorf("write creation timestamp: %w", err)
 	}
 

--- a/examples/compare/go.mod
+++ b/examples/compare/go.mod
@@ -1,6 +1,6 @@
 module github.com/pavlo-v-chernykh/keystore-go/v4/examples/compare
 
-go 1.17
+go 1.22.7
 
 require github.com/pavlo-v-chernykh/keystore-go/v4 v4.0.0
 

--- a/examples/keypass/go.mod
+++ b/examples/keypass/go.mod
@@ -1,6 +1,6 @@
 module github.com/pavlo-v-chernykh/keystore-go/v4/examples/keypass
 
-go 1.17
+go 1.22.7
 
 require github.com/pavlo-v-chernykh/keystore-go/v4 v4.0.0
 

--- a/examples/pem/go.mod
+++ b/examples/pem/go.mod
@@ -1,6 +1,6 @@
 module github.com/pavlo-v-chernykh/keystore-go/v4/examples/pem
 
-go 1.17
+go 1.22.7
 
 require github.com/pavlo-v-chernykh/keystore-go/v4 v4.0.0
 

--- a/examples/truststore/go.mod
+++ b/examples/truststore/go.mod
@@ -1,6 +1,6 @@
 module github.com/pavlo-v-chernykh/keystore-go/v4/examples/truststore
 
-go 1.17
+go 1.22.7
 
 require github.com/pavlo-v-chernykh/keystore-go/v4 v4.0.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pavlo-v-chernykh/keystore-go/v4
 
-go 1.17
+go 1.22.7

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/pavlo-v-chernykh/keystore-go/v4
 
 go 1.22.7
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/keyprotector.go
+++ b/keyprotector.go
@@ -159,7 +159,7 @@ func encrypt(rand io.Reader, plainKey []byte, password []byte) ([]byte, error) {
 	keyInfo := keyInfo{
 		Algo: pkix.AlgorithmIdentifier{
 			Algorithm:  supportedPrivateKeyAlgorithmOid,
-			Parameters: asn1.RawValue{Tag: 5},
+			Parameters: asn1.RawValue{Tag: 5}, //nolint:gomnd,mnd
 		},
 		PrivateKey: encryptedKey,
 	}

--- a/keyprotector.go
+++ b/keyprotector.go
@@ -133,7 +133,7 @@ func encrypt(rand io.Reader, plainKey []byte, password []byte) ([]byte, error) {
 	}
 
 	tmpKey := make([]byte, plainKeyLen)
-	for i := 0; i < plainKeyLen; i++ {
+	for i := range plainKeyLen {
 		tmpKey[i] = plainKey[i] ^ xorKey[i]
 	}
 

--- a/keystore.go
+++ b/keystore.go
@@ -117,7 +117,7 @@ func (ks KeyStore) Store(w io.Writer, password []byte) error {
 		return fmt.Errorf("write version: %w", err)
 	}
 
-	if err := e.writeUint32(uint32(len(ks.m))); err != nil {
+	if err := e.writeUint32(uint32(len(ks.m))); err != nil { //nolint:all
 		return fmt.Errorf("write number of entries: %w", err)
 	}
 
@@ -181,7 +181,7 @@ func (ks KeyStore) Load(r io.Reader, password []byte) error {
 		return fmt.Errorf("read number of entries: %w", err)
 	}
 
-	for i := uint32(0); i < entryNum; i++ {
+	for i := range entryNum {
 		alias, entry, err := d.readEntry(version)
 		if err != nil {
 			return fmt.Errorf("read %d entry: %w", i, err)
@@ -192,7 +192,7 @@ func (ks KeyStore) Load(r io.Reader, password []byte) error {
 
 	computedDigest := d.h.Sum(nil)
 
-	actualDigest, err := d.readBytes(uint32(d.h.Size()))
+	actualDigest, err := d.readBytes(uint32(d.h.Size())) //nolint:all
 	if err != nil {
 		return fmt.Errorf("read digest: %w", err)
 	}

--- a/keystore.go
+++ b/keystore.go
@@ -117,7 +117,7 @@ func (ks KeyStore) Store(w io.Writer, password []byte) error {
 		return fmt.Errorf("write version: %w", err)
 	}
 
-	if err := e.writeUint32(uint32(len(ks.m))); err != nil { //nolint:all
+	if err := e.writeUint32(uint32(len(ks.m))); err != nil { //nolint:gosec
 		return fmt.Errorf("write number of entries: %w", err)
 	}
 
@@ -192,7 +192,7 @@ func (ks KeyStore) Load(r io.Reader, password []byte) error {
 
 	computedDigest := d.h.Sum(nil)
 
-	actualDigest, err := d.readBytes(uint32(d.h.Size())) //nolint:all
+	actualDigest, err := d.readBytes(uint32(d.h.Size())) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("read digest: %w", err)
 	}

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -3,7 +3,6 @@ package keystore
 import (
 	"encoding/pem"
 	"os"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -48,17 +47,15 @@ func TestSetGetMethods(t *testing.T) {
 
 	pkeGet, err := ks.GetPrivateKeyEntry(pkeAlias, password)
 	require.NoError(t, err)
+	assert.Equal(t, pke, pkeGet)
 
 	chainGet, err := ks.GetPrivateKeyEntryCertificateChain(pkeAlias)
 	require.NoError(t, err)
+	assert.Equal(t, pke.CertificateChain, chainGet)
 
 	tceGet, err := ks.GetTrustedCertificateEntry(tceAlias)
 	require.NoError(t, err)
-
-	assert.True(t, reflect.DeepEqual(pke, pkeGet), "private key entries not equal")
-	assert.True(t, reflect.DeepEqual(pke.CertificateChain, chainGet),
-		"certificate chains of private key entries are not equal")
-	assert.True(t, reflect.DeepEqual(tce, tceGet), "private key entries not equal")
+	assert.Equal(t, tce, tceGet)
 
 	_, err = ks.GetPrivateKeyEntry(nonExistentAlias, password)
 	require.ErrorIs(t, err, ErrEntryNotFound)
@@ -139,14 +136,12 @@ func TestAliases(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedAliases := []string{pkeAlias, tceAlias}
-
 	sort.Strings(expectedAliases)
 
 	actualAliases := ks.Aliases()
-
 	sort.Strings(actualAliases)
 
-	assert.True(t, reflect.DeepEqual(expectedAliases, actualAliases), "aliases must be equal")
+	assert.Equal(t, expectedAliases, actualAliases)
 }
 
 func TestLoad(t *testing.T) {
@@ -182,7 +177,7 @@ func TestLoad(t *testing.T) {
 
 	decodedPK, _ := pem.Decode(pkPEM)
 
-	assert.True(t, reflect.DeepEqual(actualPKE.PrivateKey, decodedPK.Bytes), "unexpected private key")
+	assert.Equal(t, decodedPK.Bytes, actualPKE.PrivateKey, "unexpected private key")
 }
 
 func TestLoadKeyPassword(t *testing.T) {
@@ -222,8 +217,7 @@ func TestLoadKeyPassword(t *testing.T) {
 
 	decodedPK, _ := pem.Decode(pkPEM)
 
-	assert.Truef(t, reflect.DeepEqual(actualPKE.PrivateKey, decodedPK.Bytes),
-		"unexpected private key %v \n %v", actualPKE.PrivateKey, decodedPK.Bytes)
+	assert.Equal(t, decodedPK.Bytes, actualPKE.PrivateKey, "unexpected private key")
 }
 
 func readPrivateKey(t *testing.T) []byte {

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -2,13 +2,14 @@ package keystore
 
 import (
 	"encoding/pem"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetGetMethods(t *testing.T) {
@@ -55,7 +56,8 @@ func TestSetGetMethods(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, reflect.DeepEqual(pke, pkeGet), "private key entries not equal")
-	assert.True(t, reflect.DeepEqual(pke.CertificateChain, chainGet), "certificate chains of private key entries are not equal")
+	assert.True(t, reflect.DeepEqual(pke.CertificateChain, chainGet),
+		"certificate chains of private key entries are not equal")
 	assert.True(t, reflect.DeepEqual(tce, tceGet), "private key entries not equal")
 
 	_, err = ks.GetPrivateKeyEntry(nonExistentAlias, password)
@@ -170,9 +172,10 @@ func TestLoad(t *testing.T) {
 	expectedCT, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2017-09-19 17:41:00.016 +0300 EEST")
 	require.NoError(t, err)
 
-	assert.Truef(t, actualPKE.CreationTime.Equal(expectedCT), "unexpected private key entry creation time: '%v' '%v'", actualPKE.CreationTime, expectedCT)
+	assert.Truef(t, actualPKE.CreationTime.Equal(expectedCT),
+		"unexpected private key entry creation time: '%v' '%v'", actualPKE.CreationTime, expectedCT)
 
-	assert.Lenf(t, actualPKE.CertificateChain, 0, "unexpected private key entry certificate chain length: '%d' '%d'", len(actualPKE.CertificateChain), 0)
+	assert.Empty(t, actualPKE.CertificateChain, "unexpected private key entry certificate chain length")
 
 	pkPEM, err := os.ReadFile("./testdata/key.pem")
 	require.NoError(t, err)
@@ -208,16 +211,19 @@ func TestLoadKeyPassword(t *testing.T) {
 	expectedCT, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2020-10-26 12:01:38.387 +0200 EET")
 	require.NoError(t, err)
 
-	assert.Truef(t, actualPKE.CreationTime.Equal(expectedCT), "unexpected private key entry creation time: '%v' '%v'", actualPKE.CreationTime, expectedCT)
+	assert.Truef(t, actualPKE.CreationTime.Equal(expectedCT),
+		"unexpected private key entry creation time: '%v' '%v'", actualPKE.CreationTime, expectedCT)
 
-	assert.Lenf(t, actualPKE.CertificateChain, 1, "unexpected private key entry certificate chain length: '%d' '%d'", len(actualPKE.CertificateChain), 0)
+	assert.Lenf(t, actualPKE.CertificateChain, 1,
+		"unexpected private key entry certificate chain length: '%d' '%d'", len(actualPKE.CertificateChain), 0)
 
 	pkPEM, err := os.ReadFile("./testdata/key_keypass.pem")
 	require.NoError(t, err)
 
 	decodedPK, _ := pem.Decode(pkPEM)
 
-	assert.Truef(t, reflect.DeepEqual(actualPKE.PrivateKey, decodedPK.Bytes), "unexpected private key %v \n %v", actualPKE.PrivateKey, decodedPK.Bytes)
+	assert.Truef(t, reflect.DeepEqual(actualPKE.PrivateKey, decodedPK.Bytes),
+		"unexpected private key %v \n %v", actualPKE.PrivateKey, decodedPK.Bytes)
 }
 
 func readPrivateKey(t *testing.T) []byte {


### PR DESCRIPTION
Pavlo, as we wrote in the other issue about p12 support, 
I thought it's best to split the tasks. 
This is the full refactoring, so that `testify` lib is used in all tests.

Also, I did upgrade to Go 1.22.7 and this led to updates to golinter as well.
About the linter ... I spent quite some time fixing linter issues.
Therefore, you see more changes than necessary, because with Go 1.22, the linter went more "aggressive".

Any feedback is welcome.
Also, it would be great to get the 'hacktoberfest-approved' label ;) 
